### PR TITLE
Remove encoding pragma

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v3.4.0
   hooks:
-    - id: fix-encoding-pragma
     - id: end-of-file-fixer
     - id: mixed-line-ending
     - id: trailing-whitespace


### PR DESCRIPTION
Apparently this is no longer recommended (see https://github.com/asottile/pyupgrade/issues/89)