### PR TITLE
Add cli command to create quantity db entries

### DIFF
--- a/src/FINALES2/cli/database.py
+++ b/src/FINALES2/cli/database.py
@@ -1,7 +1,10 @@
+import json
+import uuid
+
 import click
 
-from FINALES2.db import Base
-from FINALES2.db.session import engine
+from FINALES2.db import Base, Quantity
+from FINALES2.db.session import engine, get_db
 
 
 @click.group("db")
@@ -19,3 +22,33 @@ def db_init():
 
     for table in Base.metadata.sorted_tables:
         click.echo(f"   {table.name}")
+
+
+@cli_db.group("add")
+def cli_add():
+    """Commands to add data to the database."""
+
+
+@click.option(
+    "--input-filepath",
+    required=True,
+    prompt="Please provide the path to a json file with the specs",
+    type=str,
+    help="Path to a json file with the specs.",
+)
+@cli_add.command("capability")
+def db_add_capability(input_filepath):
+    "Add an entry to the quantity table."
+
+    with open(input_filepath) as fileobj:
+        capability_data = json.load(fileobj)
+
+    # This should maybe be done through the engine or another internal submodule
+    capability_data["uuid"] = str(uuid.uuid4())
+    capability_data["specifications"] = json.dumps(capability_data["specifications"])
+    new_capability = Quantity(**capability_data)
+
+    with get_db() as session:
+        session.add(new_capability)
+        session.commit()
+        session.refresh(new_capability)


### PR DESCRIPTION
Example json that you can provide to this:

```
{
  "quantity": "example_q",
  "method": "example_m",
  "specifications": {
    "type": "object",
    "properties": {
      "example_p": {
        "type": "number",
        "description": "This is an example property"
      }
    },
    "required": [
      "temperature"
    ]
  },
  "is_active": true
}
```

It should be enough to call `finales db add capability --input-filepath <path_to_json_file>`