### PR TITLE
Modify schemas for result (method, params)

### DIFF
--- a/src/FINALES2/engine/main.py
+++ b/src/FINALES2/engine/main.py
@@ -82,9 +82,13 @@ class Engine:
 
         When creating the result object, it assigns a new uuid (and returns it).
         """
-        wrapped_params = {received_data.method: received_data.parameters}
+        # Note: for the results we are currently using a similar structure
+        # than the request, so the method is a list with a single entry and
+        # the parameters is a dict with a single key, named the same as the
+        # method.
+        wrapped_params = received_data.parameters
         self.validate_submission(
-            received_data.quantity, [received_data.method], wrapped_params
+            received_data.quantity, received_data.method, wrapped_params
         )
 
         db_obj = DbResult(
@@ -92,7 +96,7 @@ class Engine:
                 "uuid": str(uuid.uuid4()),
                 "request_uuid": str(uuid.uuid4()),  # get from received data and check
                 "quantity": received_data.quantity,
-                "method": received_data.method,
+                "method": json.dumps(received_data.method),
                 "parameters": json.dumps(received_data.parameters),
                 "data": json.dumps(received_data.data),
                 "posting_tenant_uuid": str(uuid.uuid4()),  # get from auth metadata

--- a/src/FINALES2/server/schemas.py
+++ b/src/FINALES2/server/schemas.py
@@ -51,8 +51,8 @@ class RequestInfo(BaseModel):
 class Result(BaseModel):
     data: dict
     quantity: str
-    method: str
-    parameters: dict
+    method: List[str]
+    parameters: Dict[str, dict]
     tenant_uuid: str
     request_uuid: str
 
@@ -62,7 +62,7 @@ class Result(BaseModel):
         init_params = {
             "data": json.loads(db_result.data),
             "quantity": db_result.quantity,
-            "method": "none",
+            "method": json.loads(db_result.method),
             "parameters": json.loads(db_result.parameters),
             "tenant_uuid": str(db_result.posting_tenant_uuid),
             "request_uuid": str(db_result.posting_tenant_uuid),


### PR DESCRIPTION
They are now `expected` to be a list with a single str value (method) and a dict with a single entry with the same name as the method (params). Note that so far this is not enforced, checks need to be set in place to make sure there is only one item in each of these.