### PR TITLE
Added more packages to the requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ install_requires =
     click
     fastapi
     jose
-    jsonschemas
+    jsonschema
     numpy
     passlib
     pre-commit


### PR DESCRIPTION
- the packages were not included in the requirements and therefore needed to be installed manually, because this was causing an error otherwise.