### PR TITLE
Bug fix for method uuid matching result/request

### DIFF
--- a/src/FINALES2/server/schemas.py
+++ b/src/FINALES2/server/schemas.py
@@ -70,7 +70,7 @@ class Request(BaseModel):
             select(DbQuantity.quantity, DbQuantity.method)
             .join(DBLinkQuantityRequest)
             .join(DbRequest)
-            .where(DbRequest.uuid == DBLinkQuantityRequest.request_uuid)
+            .where(db_request.uuid == DBLinkQuantityRequest.request_uuid)
             .where(DbQuantity.uuid == DBLinkQuantityRequest.method_uuid)
         )
 
@@ -142,7 +142,7 @@ class Result(BaseModel):
             select(DbQuantity.quantity, DbQuantity.method)
             .join(DBLinkQuantityResult)
             .join(DbResult)
-            .where(DbResult.uuid == DBLinkQuantityResult.result_uuid)
+            .where(db_result.uuid == DBLinkQuantityResult.result_uuid)
             .where(DbQuantity.uuid == DBLinkQuantityResult.method_uuid)
         )
 


### PR DESCRIPTION
There was a bug when matching methods for requests and results through the linking tables.
Instead of enforcing a where clause on a specific uuid, it instead just matched up all uuid present in the tables.

This has been fixed.

We did not see this problem earlier since the testing has been done with a single request/result