### PR TITLE
FIX: auto-create parent folder for userdb

### DIFF
--- a/src/FINALES2/config/__init__.py
+++ b/src/FINALES2/config/__init__.py
@@ -24,6 +24,22 @@ class FinalesConfiguration(BaseModel):
     algorithm: str = "HS256"
     token_expiration_min: int = 1440
 
+    def safeget_userdb(self):
+        """A way to get the user_db that makes sure the folder exists.
+
+        NOTE: Ideally this should be implemented with an intrinsic
+        getter or defining a property, but it is not trivial to do
+        this in a way that is compatible with pydantic.
+        """
+        userdb_dirpath = Path(self.user_db).resolve().parent
+        if not userdb_dirpath.exists():
+            print(
+                f"Parent path {userdb_dirpath} for the user_db does not exist,"
+                f"creating it."
+            )
+            userdb_dirpath.mkdir(parents=True)
+        return self.user_db
+
 
 def get_configuration():
     """Returns the dict with configuration for FINALES."""
@@ -50,4 +66,5 @@ def get_configuration():
     with open(config_filepath) as fileobj:
         config_data = json.load(fileobj)
         config_object = FinalesConfiguration(**config_data)
-        return config_object
+
+    return config_object

--- a/src/FINALES2/user_management/user_manager.py
+++ b/src/FINALES2/user_management/user_manager.py
@@ -44,7 +44,7 @@ class UserDB:
         """
         if savepath is None:
             config = get_configuration()
-            savepath = config.user_db
+            savepath = config.safeget_userdb()
 
         # Connect to this database and set the cursor
         self.connection: sqlite3.Connection = sqlite3.connect(savepath)


### PR DESCRIPTION
Instead of directly accessing the `user_db` field of the configuration,
now one can use the `safeget_userdb` method which returns that same
`user_db` but it first checks that the containing folders exist.