### PR TITLE
Changes to adapt to pydantic V2

### DIFF
--- a/src/FINALES2/config/__init__.py
+++ b/src/FINALES2/config/__init__.py
@@ -58,7 +58,7 @@ def get_configuration():
         parent_path = config_filepath.parent
         parent_path.mkdir(parents=True, exist_ok=True)
         default_config = FinalesConfiguration()
-        default_config_data = default_config.dict()
+        default_config_data = default_config.model_dump()
         with open(config_filepath, "w") as fileobj:
             json.dump(default_config_data, fileobj, indent=2)
         return default_config

--- a/src/FINALES2/schemas.py
+++ b/src/FINALES2/schemas.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 class GeneralMetaData(BaseModel):
     name: str
-    description: Optional[str]
+    description: Optional[str] = None
 
 
 class Method(BaseModel):
@@ -21,7 +21,7 @@ class Method(BaseModel):
 class Quantity(BaseModel):
     name: str
     methods: dict[str, Method]
-    specifications: Optional[dict]
+    specifications: Optional[dict] = None
     is_active: bool
 
 

--- a/src/FINALES2/tenants/referenceTenant.py
+++ b/src/FINALES2/tenants/referenceTenant.py
@@ -23,12 +23,12 @@ class Tenant(BaseModel):
     quantities: dict[str, Quantity]
     queue: list = []
     sleep_time_s: int = 1
-    tenant_config: Any
+    tenant_config: Any = None
     run_method: Callable
     prepare_results: Callable
     FINALES_server_config: ServerConfig
-    end_run_time: Optional[datetime]
-    authorization_header: Optional[dict]
+    end_run_time: Optional[datetime] = None
+    authorization_header: Optional[dict] = None
     operator: User
     tenant_user: User
     tenant_uuid: str


### PR DESCRIPTION
The changes to enable usage of pydantic V2 comprise:
- adding default values of None to optional fields
- changing .dict() applied to classes based on the BaseModel to .model_dump()