### PR TITLE
Cli commands for capability and tenant control

### DIFF
--- a/src/FINALES2/cli/database.py
+++ b/src/FINALES2/cli/database.py
@@ -133,7 +133,7 @@ def cli_retrieve():
 )
 @cli_retrieve.command("tenant-uuid")
 def db_retrieve_tenant_specification(input_name=None):
-    "Alter the is_active state of a tenant"
+    "Retrieve uuid of all tenants, or just the one with an above specified name"
 
     server_manager = ServerManager(database_context=get_db)
     server_manager.retrieve_tenant_uuid(input_name)

--- a/src/FINALES2/engine/server_manager.py
+++ b/src/FINALES2/engine/server_manager.py
@@ -302,18 +302,21 @@ class ServerManager:
         )
         return
 
-    def retrieve_tenant_uuid(self, tenant_uuid):
-        """Adds new state to a capability."""
+    def retrieve_tenant_uuid(self, tenant_name):
+        """Retrive uuid from tenant with provided tenant_name. If tenant_name is None
+        provide all tenant names with corresponding uuid"""
         query_inp = select(Tenant)
-        if tenant_uuid is not None:
-            query_inp = query_inp.where(Tenant.uuid == uuid.UUID(tenant_uuid))
+        if tenant_name is not None:
+            query_inp = query_inp.where(Tenant.name == tenant_name)
 
         with self._database_context() as session:
             query_out = session.execute(query_inp).all()
 
             if len(query_out) == 0:
-                if tenant_uuid is None:
-                    raise ValueError("No tenant exists with the provided name")
+                if tenant_name is None:
+                    raise ValueError(
+                        f"No tenant exists with the provided name ({tenant_name})"
+                    )
                 else:
                     raise ValueError("No tenants in the database")
 


### PR DESCRIPTION
Cli commands for tenant and capability control

- deactivate a capability. This is irreversible, and should only be done if new specifications are needed for the capability for tenants to connect
- alter state of tenant: set tenant to is_active = 1 or 0.
- cli command for retrieving uuid of tenants
- Bug found in the query for the dublicate check for capabilities -  fixed