### PR TITLE
FIX: Simplify limitations

### DIFF
--- a/src/FINALES2/engine/server_manager.py
+++ b/src/FINALES2/engine/server_manager.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from typing import Any, Dict, List, Optional
 
-import jsonref
+from jsonref import JsonRef
 from jsonschema import validate
 from sqlalchemy import select
 
@@ -193,7 +193,7 @@ class ServerManager:
             )
 
         capability_schema = capability_info[0].json_schema_specifications
-        capability_schema = jsonref.replace_refs(capability_schema)
+        capability_schema = JsonRef.replace_refs(capability_schema)
         limitations_schema = limitations_schema_translation(capability_schema)
         limitations = limitations["limitations"]
         validate(instance=limitations, schema=limitations_schema)
@@ -335,39 +335,47 @@ def limitations_schema_translation(inputs_schema: Dict[str, Any]) -> Dict[str, A
     if len(inputs_schema) == 0:
         return {"additionalProperties": False}
 
-    # Every object in the schema becomes an array of objects with the
-    # possible values (or ranges).
-    limitations_schema: Dict[str, Any] = {"type": "array"}
+    limitations_schema: Dict[str, Any] = {}
 
     # The title is not necessary but may be useful for debugging at runtime
     if "title" in inputs_schema:
         limitations_schema["title"] = inputs_schema["title"]
 
-    # Now I need to set the "items" descriptor of the array, which contains
-    # the type of the objects in it.
-
+    # For some reason, some of the schemas generated contain the "allOf"
+    # keyword with a single list element instead of just that element.
+    # If this is the case, just return the subschema of that.
     if "allOf" in inputs_schema:
-        # For some reason, some of the schemas generated contain the
-        # "allOf" keyword with a single list element instead of just
-        # describing that element.
+        limitations_schema["allOf"] = []
         subschemas = inputs_schema["allOf"]
         if len(subschemas) > 1:
             raise ValueError(
                 "Schema contains an instance of `allOf` with more than 1 element!"
             )
-        subschema_translated = limitations_schema_translation(subschemas[0])
-        if "title" in subschema_translated:
-            limitations_schema["title"] = subschema_translated["title"]
-        limitations_schema["items"] = subschema_translated["items"]
+        subschema_translation = limitations_schema_translation(subschemas[0])
+        limitations_schema["allOf"].append(subschema_translation)
+        return limitations_schema
 
-    elif "anyOf" in inputs_schema:
-        # If the object could have many types, it will not have a "type"
-        # descriptor but an "anyOf" list of descriptors. I need to go
-        # through all of them and add them as an "anyOf" in the "items".
-        limitations_schema["items"] = {"anyOf": []}
-        for schema_item in inputs_schema["anyOf"]:
-            new_schema = limitations_schema_translation(schema_item)
-            limitations_schema["items"]["anyOf"].append(new_schema)
+    # If the schema is actually one of many possible subschemas, there
+    # might be different limitations for the different possible
+    # sub-schemas.
+    if "anyOf" in inputs_schema:
+        limitations_schema["anyOf"] = []
+        for subschema in inputs_schema["anyOf"]:
+            subschema_translation = limitations_schema_translation(subschema)
+            limitations_schema["anyOf"].append(subschema_translation)
+        return limitations_schema
+
+    # Every object in the schema can now be either an instance of what it
+    # is already described (when that is the only option) or an array of
+    # objects of that same type, with the possible values (or ranges).
+    single_object_schema = {"type": inputs_schema["type"]}
+
+    if inputs_schema["type"] == "array":
+        # If the object was an array, the type is defined inside of "items".
+        new_items = inputs_schema["items"]
+        new_items = limitations_schema_translation(new_items)
+        schema_items = new_items
+        single_object_schema["items"] = new_items
 
     elif inputs_schema["type"] in ["number", "integer"]:
         # If the object was a numeric type, the type of the possibilities
@@ -384,30 +392,35 @@ def limitations_schema_translation(inputs_schema: Dict[str, Any]) -> Dict[str, A
             },
             "additionalProperties": False,
         }
-        limitations_schema["items"] = {"anyOf": [range_schema, cases_schema]}
-
-    elif inputs_schema["type"] == "array":
-        # If the object was an array, the type is defined inside of "items".
-        new_items = inputs_schema["items"]
-        new_items = limitations_schema_translation(new_items)
-        limitations_schema["items"] = new_items
+        schema_items = {"anyOf": [range_schema, cases_schema]}
 
     else:
-        # If the object was a string or any other, the type is defined
-        # inside of "type". If it was a string then this is over, but
-        # if it was another custom type, I need to go throught its
-        # properties and add them recursively.
-        limitations_schema["items"] = {"type": inputs_schema["type"]}
+        # If the object was a string or any other type (except arrays
+        # or numerics) the type is defined inside of "type" (duh). If
+        # it was a string then this is over, but if it was another
+        # custom type, I need to go throught its properties and add
+        # them recursively.
+        schema_items = {"type": inputs_schema["type"]}
 
         if "properties" in inputs_schema:
-            limitations_schema["items"]["properties"] = {}
+            subschema_properties = {}
             for propery_name, property_schema in inputs_schema["properties"].items():
                 new_property = limitations_schema_translation(property_schema)
-                limitations_schema["items"]["properties"][propery_name] = new_property
+                subschema_properties[propery_name] = new_property
+            schema_items["properties"] = subschema_properties
+            single_object_schema["properties"] = subschema_properties
 
         if "additionalProperties" in inputs_schema:
             new_property = inputs_schema["additionalProperties"]
             new_property = limitations_schema_translation(new_property)
-            limitations_schema["items"]["additionalProperties"] = new_property
+            schema_items["additionalProperties"] = new_property
+            single_object_schema["additionalProperties"] = new_property
+
+    # As stated before, the limitations can either be a single possible
+    # instance of the schema, or the array.
+    limitations_schema["anyOf"] = [
+        single_object_schema,
+        {"type": "array", "items": schema_items},
+    ]
 
     return limitations_schema

--- a/src/FINALES2/tests/engine/server_manager_test.py
+++ b/src/FINALES2/tests/engine/server_manager_test.py
@@ -1,8 +1,8 @@
 import typing as ty
 
-import jsonref
 import jsonschema
 import pytest
+from jsonref import JsonRef
 from pydantic import BaseModel
 
 from FINALES2.engine.server_manager import limitations_schema_translation
@@ -31,14 +31,14 @@ class TestLimitationsSchemaTranslation:
     def test_empty_limitations(self, capability_schema):
         """Test empty limitations."""
         limitations = [{}]
-        capability_schema = jsonref.replace_refs(capability_schema)
+        capability_schema = JsonRef.replace_refs(capability_schema)
         limitations_schema = limitations_schema_translation(capability_schema)
         jsonschema.validate(instance=limitations, schema=limitations_schema)
 
     def test_numeric_ranges(self, capability_schema):
         """Test partial numeric ranges."""
         limitations = [{"temperature": [{"max": 400, "step": 2}, 0]}]
-        capability_schema = jsonref.replace_refs(capability_schema)
+        capability_schema = JsonRef.replace_refs(capability_schema)
         limitations_schema = limitations_schema_translation(capability_schema)
         jsonschema.validate(instance=limitations, schema=limitations_schema)
 
@@ -48,7 +48,7 @@ class TestLimitationsSchemaTranslation:
             {"temperature": [{"min": 200, "max": 400, "step": 2}], "unit": ["Kelvin"]},
             {"temperature": [{"min": -73, "max": 273, "step": 2}], "unit": ["Celcius"]},
         ]
-        capability_schema = jsonref.replace_refs(capability_schema)
+        capability_schema = JsonRef.replace_refs(capability_schema)
         limitations_schema = limitations_schema_translation(capability_schema)
         jsonschema.validate(instance=limitations, schema=limitations_schema)
 
@@ -64,7 +64,7 @@ class TestLimitationsSchemaTranslation:
                 "compounds": [[compound1, compound2], [compound2, compound3]],
             },
         ]
-        capability_schema = jsonref.replace_refs(capability_schema)
+        capability_schema = JsonRef.replace_refs(capability_schema)
         limitations_schema = limitations_schema_translation(capability_schema)
         jsonschema.validate(instance=limitations, schema=limitations_schema)
 
@@ -78,20 +78,22 @@ class TestLimitationsSchemaTranslation:
             # Wrong key in definition of a range
             [{"temperature": [{"minimum": "string"}, 0]}],
             # Arrays should receive arrays of arrays, not just arrays
-            [
-                {
-                    "compounds": [
-                        {"formula": ["H2O"], "concentration": [0.8]},
-                        {"formula": ["CH3CH2OH"], "concentration": [0.2]},
-                        {"formula": ["C6H14"], "concentration": [0.4]},
-                    ],
-                }
-            ],
+            # This is not currently the case so the test case is
+            # removed, but we should really try to go back to this.
+            #            [
+            #                {
+            #                    "compounds": [
+            #                        {"formula": ["H2O"], "concentration": [0.8]},
+            #                        {"formula": ["CH3CH2OH"], "concentration": [0.2]},
+            #                        {"formula": ["C6H14"], "concentration": [0.4]},
+            #                    ],
+            #                }
+            #            ],
         ],
     )
     def test_incorrect_limitations(self, limitations, capability_schema):
         """Test that the code raises with incorrect limitations."""
-        capability_schema = jsonref.replace_refs(capability_schema)
+        capability_schema = JsonRef.replace_refs(capability_schema)
         limitations_schema = limitations_schema_translation(capability_schema)
         with pytest.raises(jsonschema.exceptions.ValidationError):
             jsonschema.validate(instance=limitations, schema=limitations_schema)


### PR DESCRIPTION
This PR addresses a couple of issues we were starting to have with the way
in which the limitations were currently working.

- For some reason, some of the schemas generated contain the "allOf"
  keyword with a single list element instead of just describing that element.
  This wasn't considered and was causing issues with tenant registry.
  Currently this unnecessary "allOf" is preserved in the limitations (but
  will raise if it has more than 1 element).

- The way "anyOf" was being translated ended up adding an additional
  array wrapping that was unnecessary. This is now fixed.

- Finally, having to wrap everything around lists (even if there was only
  one option for the field) was over complicating the process of registering
  a tenant. Now the limitations also accept an instance of the object in
  addition to an array with elements.

This fixes #152 and #185