### PR TITLE
FIX: auth-protect `/capabilities/template` endpoint

### DIFF
--- a/src/FINALES2/server/endpoints.py
+++ b/src/FINALES2/server/endpoints.py
@@ -220,6 +220,7 @@ def get_templates(
     quantity: Optional[str] = None,
     method: Optional[str] = None,
     currently_available=True,
+    token: User = Depends(user_manager.get_active_user),
 ) -> Dict[str, Dict[str, Any]]:
     """API endpoint to get templates for the input and output schemas for the
     queried quantity and/or method. It can also provide templates for all of the


### PR DESCRIPTION
The `/capabilities/template` endpoint was not protected with the user authentication feature.