### PR TITLE
FIX: Wrong type for the content of the limitations

### DIFF
--- a/src/FINALES2/server/schemas.py
+++ b/src/FINALES2/server/schemas.py
@@ -172,4 +172,4 @@ class CapabilityInfo(BaseModel):
 class LimitationsInfo(BaseModel):
     quantity: str
     method: str
-    limitations: Dict[str, Any]
+    limitations: List[Dict[str, Any]]


### PR DESCRIPTION
Removing the `anyOf` made the limitations incompatible
with their pydantic class description (see #196).