### PR TITLE
Bugfix validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,6 @@ The tutorial I followed and further details can be found in the following two li
 [https://packaging.python.org/en/latest/tutorials/packaging-projects/](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
 
 
-## Acknowledgements
+# Acknowledgements
 
-This project has received funding from the European Union’s [Horizon 2020 research and innovation programme](https://ec.europa.eu/programmes/horizon2020/en) under grant agreement [No 957189](https://cordis.europa.eu/project/id/957189).
+This project received funding from the European Union’s [Horizon 2020 research and innovation programme](https://ec.europa.eu/programmes/horizon2020/en) under grant agreement [No 957189](https://cordis.europa.eu/project/id/957189) (BIG-MAP). The authors acknowledge BATTERY2030PLUS, funded by the European Union’s Horizon 2020 research and innovation program under grant agreement no. 957213. This work contributes to the research performed at CELEST (Center for Electrochemical Energy Storage Ulm-Karlsruhe) and was co-funded by the German Research Foundation (DFG) under Project ID 390874152 (POLiS Cluster of Excellence).

--- a/src/FINALES2/engine/main.py
+++ b/src/FINALES2/engine/main.py
@@ -351,9 +351,11 @@ class Engine:
         # followed by inactive ones in reverse chronological order (newest first).
         # In this way, FINALES will check new submissions agains either the
         # currently active specification or the one that was last registered.
-        query_inp = select(DbQuantity).order_by(
-            DbQuantity.is_active.desc(), DbQuantity.load_time.desc()
-            ).where(DbQuantity.quantity == quantity)
+        query_inp = (
+            select(DbQuantity)
+            .order_by(DbQuantity.is_active.desc(), DbQuantity.load_time.desc())
+            .where(DbQuantity.quantity == quantity)
+        )
         with get_db() as session:
             query_out = session.execute(query_inp).all()
 
@@ -367,7 +369,8 @@ class Engine:
                 logger.raise_value_error(
                     logger=logger,
                     msg=(
-                        f"Method for params with key {method} not found in list: "
+                        f"Method for params with key {method} "
+                        "not found in list: "
                         f"{methods}"
                     ),
                 )
@@ -376,7 +379,11 @@ class Engine:
             if method not in parameters.keys():
                 logger.raise_value_error(
                     logger=logger,
-                    msg=f"Method {method} not found in parameters: {parameters.keys()}",
+                    msg=(
+                        f"Method {method} "
+                        "not found in parameters: "
+                        f"{parameters.keys()}"
+                    ),
                 )
 
             match_found = False

--- a/src/FINALES2/engine/main.py
+++ b/src/FINALES2/engine/main.py
@@ -347,14 +347,11 @@ class Engine:
         self, quantity: str, methods: List[str], parameters: Dict[str, dict]
     ):
         """Validates"""
-        # Find all specifications of this quantity and fist list the active one
-        # followed by inactive ones in reverse chronological order (newest first).
-        # In this way, FINALES will check new submissions agains either the
-        # currently active specification or the one that was last registered.
-        query_inp = (
-            select(DbQuantity)
-            .order_by(DbQuantity.is_active.desc(), DbQuantity.load_time.desc())
-            .where(DbQuantity.quantity == quantity)
+        # Find the active specification for this quantity.
+        # In this way, FINALES will check new submissions agains the
+        # currently active specification.
+        query_inp = select(DbQuantity).where(
+            (DbQuantity.quantity == quantity) & (DbQuantity.is_active == 1)
         )
         with get_db() as session:
             query_out = session.execute(query_inp).all()

--- a/src/FINALES2/engine/main.py
+++ b/src/FINALES2/engine/main.py
@@ -347,7 +347,13 @@ class Engine:
         self, quantity: str, methods: List[str], parameters: Dict[str, dict]
     ):
         """Validates"""
-        query_inp = select(DbQuantity).where(DbQuantity.quantity == quantity)
+        # Find all specifications of this quantity and fist list the active one
+        # followed by inactive ones in reverse chronological order (newest first).
+        # In this way, FINALES will check new submissions agains either the
+        # currently active specification or the one that was last registered.
+        query_inp = select(DbQuantity).order_by(
+            DbQuantity.is_active.desc(), DbQuantity.load_time.desc()
+            ).where(DbQuantity.quantity == quantity)
         with get_db() as session:
             query_out = session.execute(query_inp).all()
 

--- a/src/FINALES2/engine/main.py
+++ b/src/FINALES2/engine/main.py
@@ -358,7 +358,7 @@ class Engine:
 
         if len(query_out) == 0:
             logger.raise_value_error(
-                logger=logger, msg=f"No records for this quantity: {quantity}"
+                logger=logger, msg=f"No active records for this quantity: {quantity}"
             )
 
         for method in parameters.keys():


### PR DESCRIPTION
FINALES always compared submissions to the first schema it found in the database. This is not desired, if the schema got updated. This fix makes FINALES to first search for the an active schema for the capability and subsequently list the inactive ones with the latest registered one first.

In this way, updated schemas are actually considered.