### PR TITLE
use fully qualified image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.12.0
+FROM docker.io/continuumio/miniconda3:4.12.0
 
 # --- Installing relevant tools
 RUN apt-get update && \


### PR DESCRIPTION
required to build with buildah and makes the build independent of non-default docker configurations

closes #254 